### PR TITLE
Builder: Switch to openssl1.1-compat-dev

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY --from=Builder --chown=root:root /home/effortman/.abuild/*.rsa.pub /etc/apk
 # RUN rm -rf /root/packages/
 RUN apk --no-cache add \
     build-base clang dtools dub git ldc libsodium-dev linux-headers llvm-libunwind-dev npm \
-    openssl-dev python3 sqlite-dev zlib-dev
+    openssl1.1-compat-dev python3 sqlite-dev zlib-dev


### PR DESCRIPTION
OpenSSL 3.0 is now the default on Alpine, but the Deimos bindings
do not support it, so we need to stick to v1.1 for the time being.