### PR TITLE
Revert to regular openssl package / rebuild the builder

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+dub/src/
+ldc/src/

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 # Emacs files
 *~
+
+# Build artifacts
+dub/src/
+ldc/src/

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,4 +16,4 @@ COPY --from=Builder --chown=root:root /home/effortman/.abuild/*.rsa.pub /etc/apk
 # RUN rm -rf /root/packages/
 RUN apk --no-cache add \
     build-base clang dtools dub git ldc libsodium-dev linux-headers llvm-libunwind-dev npm \
-    openssl1.1-compat-dev python3 sqlite-dev zlib-dev
+    openssl-dev python3 sqlite-dev zlib-dev


### PR DESCRIPTION
I was trying a few things, and due to the outdated base package, I couldn't really make progress.