### PR TITLE
Dockerfile: Temporarily use Alpine v3.15

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ ADD --chown=effortman:abuild dub/ /build/dub/
 #WORKDIR /build/dub/
 #RUN abuild -r
 
-FROM alpine:edge
+FROM alpine:3.15
 COPY --from=Builder --chown=root:root /home/effortman/.abuild/*.rsa.pub /etc/apk/keys/
 #COPY --from=Builder /home/effortman/packages/ /root/packages
 #RUN apk --no-cache add -X /root/packages/build/ ldc=1.28.0-r0 dub=1.26.0-r0


### PR DESCRIPTION
Upstream temporarily broke the LDC package, so our CI pipelines are stuck.
We need to downgrade to v3.15 (released 2021-11-24) to not be blocked waiting.